### PR TITLE
Adding Changes made by @douggillespie to support old format of ctr files.

### DIFF
--- a/ARTwarp_Load_Data.m
+++ b/ARTwarp_Load_Data.m
@@ -12,14 +12,24 @@ DATA = rmfield(DATA,'datenum');
 DATA = rmfield(DATA,'bytes');
 DATA = rmfield(DATA,'isdir');
 [numSamples x] = size(DATA);
+
+% this line is needed to ctrick Matlab into beleiving that fcontour is a
+% variable (which it will be soon) and to stop it trying to use the built
+% in graphics function fcontour(...)
+fcontour = 0;
 for c1 = 1:numSamples
     clear tempres
     clear ctrlength
+    clear fcontour
     eval(['load ' DATA(c1).name ' -mat']);
     if exist('ctrlength', 'var')
         DATA(c1).ctrlength = ctrlength;
         DATA(c1).length = length(freqContour);
         DATA(c1).contour = freqContour;
+    elseif exist('fcontour', 'var')
+        DATA(c1).ctrlength = fcontour(length(fcontour))/1000;
+        DATA(c1).length = length(fcontour);
+        DATA(c1).contour = fcontour(1:DATA(c1).length);
     else
         DATA(c1).ctrlength = freqContour(length(freqContour))/1000;
         DATA(c1).length = length(freqContour)-1;

--- a/ARTwarp_csv.m
+++ b/ARTwarp_csv.m
@@ -4,7 +4,9 @@ close gcf
 
 global vigilance bias learningRate maxNumCategories maxNumIterations sampleInterval resample callback2
 
-load ARTwarp.mat
+load Default.mat
+
+addpath(pwd);
 
 % GENERATE FIGURE
 h0 = figure('Units','normalized', ...


### PR DESCRIPTION
These changes made by @douggillespie allow these older formats of ctr files to run. Here is the email discussing this issue: 
The ctr files @RohanK22 was testing with are from an old format. The data in them had the two variables fcontour and ostart, no freqContour. It seems the fcontour is now a built in Matlab function, which might explain a change from fcontour to freqContour. There is a bug whereby Matlab is getting very confused as to whether to use fcontour as the variable or as the function. Because fcontour does not appear as a variable name in the code, at the start of run time, the interpreter analyses the code, sees that there is no fcontour variable, and links to the function. fcontour is later created from the ctr file during the run, but it’s too late because the interpreter has already decided that it’s going to use the function, which of course fails. There is actually an easy work around – create a variable fcontour, then clear it at the top of the function, to trick the interpreter into assuming it’s a variable.

These changes were used to run ARTwarp successfully with the Killer Whale ctr files on OneDrive at "Steno Output/ARTwarp/Killer whale sample contours/". 