### PR TITLE
Fix path change issue when loading data into ARTwarp

### DIFF
--- a/ARTwarp_Load_CSV_Data.m
+++ b/ARTwarp_Load_CSV_Data.m
@@ -6,7 +6,6 @@ function ARTwarp_Load_CSV_Data
 global DATA numSamples tempres
 
 path = uigetdir('*.ctr', 'Select the folder containing the contour files');
-eval(['cd ' path]);
 path = [path '/*csv'];
 DATA = dir(path);
 DATA = rmfield(DATA,'date');
@@ -20,7 +19,7 @@ for c1 = 1:numSamples
     % csvread only works with numeric values.  The frequency should be in
     % the second column
    % test=csvread(DATA(c1).name,0,0);    %this is if you don't want it to skip the header row...IS THAT RIGHT??
-    test=csvread(DATA(c1).name,1,0);   %this is if you want it to skip the
+    test=csvread(append(DATA(c1).folder, '/', DATA(c1).name),1,0);   %this is if you want it to skip the
     %header row
     freqContour = test(:,1);
     DATA(c1).ctrlength = freqContour(length(freqContour))/1000;

--- a/ARTwarp_Load_CSV_Data.m
+++ b/ARTwarp_Load_CSV_Data.m
@@ -19,7 +19,7 @@ for c1 = 1:numSamples
     % csvread only works with numeric values.  The frequency should be in
     % the second column
    % test=csvread(DATA(c1).name,0,0);    %this is if you don't want it to skip the header row...IS THAT RIGHT??
-    test=csvread(append(DATA(c1).folder, '/', DATA(c1).name),1,0);   %this is if you want it to skip the
+    test=csvread(fullfile(DATA(c1).folder, DATA(c1).name),1,0);   %this is if you want it to skip the
     %header row
     freqContour = test(:,1);
     DATA(c1).ctrlength = freqContour(length(freqContour))/1000;

--- a/ARTwarp_Load_Data.m
+++ b/ARTwarp_Load_Data.m
@@ -1,10 +1,10 @@
 % This function loads all .ctr files in a user-selected directory into a DATA array 
 function ARTwarp_Load_Data
 
-global DATA numSamples tempres
+global DATA numSamples tempres artwarpPath
 
 path = uigetdir('*.ctr', 'Select the folder containing the contour files');
-cd(path);
+cd(path); % Change path to data directory
 path = [path '/*ctr'];
 DATA = dir(path);
 DATA = rmfield(DATA,'date');
@@ -43,5 +43,7 @@ for c1 = 1:numSamples
     DATA(c1).category = 0;
 end
 h = findobj('Tag', 'Runmenu');                                                                                                                        
-set(h, 'Enable', 'on');
+set(h, 'Enable', 'on'); 
 
+% Restore path to ARTwarp code directory
+cd(artwarpPath);

--- a/ARTwarp_Load_Data.m
+++ b/ARTwarp_Load_Data.m
@@ -1,10 +1,9 @@
 % This function loads all .ctr files in a user-selected directory into a DATA array 
 function ARTwarp_Load_Data
 
-global DATA numSamples tempres artwarpPath
+global DATA numSamples tempres
 
 path = uigetdir('*.ctr', 'Select the folder containing the contour files');
-cd(path); % Change path to data directory
 path = [path '/*ctr'];
 DATA = dir(path);
 DATA = rmfield(DATA,'date');
@@ -21,7 +20,7 @@ for c1 = 1:numSamples
     clear tempres
     clear ctrlength
     clear fcontour
-    eval(['load ' DATA(c1).name ' -mat']);
+    eval(['load ' append(DATA(c1).folder, '/', DATA(c1).name) ' -mat']);
     if exist('ctrlength', 'var')
         DATA(c1).ctrlength = ctrlength;
         DATA(c1).length = length(freqContour);
@@ -44,6 +43,3 @@ for c1 = 1:numSamples
 end
 h = findobj('Tag', 'Runmenu');                                                                                                                        
 set(h, 'Enable', 'on'); 
-
-% Restore path to ARTwarp code directory
-cd(artwarpPath);

--- a/ARTwarp_Load_Data.m
+++ b/ARTwarp_Load_Data.m
@@ -20,7 +20,7 @@ for c1 = 1:numSamples
     clear tempres
     clear ctrlength
     clear fcontour
-    eval(['load ' append(DATA(c1).folder, '/', DATA(c1).name) ' -mat']);
+    eval(['load ' fullfile(DATA(c1).folder, DATA(c1).name) ' -mat']);
     if exist('ctrlength', 'var')
         DATA(c1).ctrlength = ctrlength;
         DATA(c1).length = length(freqContour);

--- a/ARTwarp_csv.m
+++ b/ARTwarp_csv.m
@@ -2,14 +2,11 @@
 clear all
 close gcf
 
-global vigilance bias learningRate maxNumCategories maxNumIterations sampleInterval resample callback2 artwarpPath
+global vigilance bias learningRate maxNumCategories maxNumIterations sampleInterval resample callback2
 
 load Default.mat
 
 addpath(pwd);
-
-% Save the path to the code directory
-artwarpPath=pwd;
 
 % GENERATE FIGURE
 h0 = figure('Units','normalized', ...

--- a/ARTwarp_csv.m
+++ b/ARTwarp_csv.m
@@ -2,11 +2,14 @@
 clear all
 close gcf
 
-global vigilance bias learningRate maxNumCategories maxNumIterations sampleInterval resample callback2
+global vigilance bias learningRate maxNumCategories maxNumIterations sampleInterval resample callback2 artwarpPath
 
 load Default.mat
 
 addpath(pwd);
+
+% Save the path to the code directory
+artwarpPath=pwd;
 
 % GENERATE FIGURE
 h0 = figure('Units','normalized', ...


### PR DESCRIPTION
It is a very simple fix that just saves the current path in a global variable before loading the data, and after the data is loaded it restores the current working directory back to the ARTwarp code directory. 